### PR TITLE
Added uvTwirl and screenPosition custom nodes

### DIFF
--- a/nme/customFrames/screenPosition.json
+++ b/nme/customFrames/screenPosition.json
@@ -2,59 +2,58 @@
   "editorData": {
     "locations": [
       {
-        "blockId": 5863,
-        "x": 280,
-        "y": 1000
+        "blockId": 865,
+        "x": 735,
+        "y": 490
       },
       {
-        "blockId": 5862,
-        "x": 660,
-        "y": 1000
+        "blockId": 868,
+        "x": 735,
+        "y": 735
       },
       {
-        "blockId": 5865,
-        "x": 660,
-        "y": 1180
+        "blockId": 866,
+        "x": 1120,
+        "y": 490
       },
       {
-        "blockId": 5864,
-        "x": 280,
-        "y": 1240
+        "blockId": 867,
+        "x": 1120,
+        "y": 665
       },
       {
-        "blockId": 5861,
-        "x": 1000,
-        "y": 1040
+        "blockId": 869,
+        "x": 1470,
+        "y": 525
       }
     ],
     "frames": [
       {
-        "x": 140,
-        "y": 940,
-        "width": 1233.17,
-        "height": 140,
+        "x": 630,
+        "y": 420,
+        "width": 1109.8,
+        "height": 475.537,
         "color": [
-          0.0392156862745098,
-          0.15294117647058825,
-          0.06666666666666667
+          0.050980392156862744,
+          0.12156862745098039,
+          0.03137254901960784
         ],
-        "name": "Screen Position",
+        "name": "ScreenPosition",
         "isCollapsed": true,
         "blocks": [
-          5863,
-          5862,
-          5865,
-          5864,
-          5861
-        ],
-        "comments": "Screen position [0..1]"
+          865,
+          868,
+          866,
+          867,
+          869
+        ]
       }
     ]
   },
   "blocks": [
     {
       "customType": "BABYLON.FragCoordBlock",
-      "id": 5863,
+      "id": 865,
       "name": "FragCoord",
       "comments": "",
       "visibleInInspector": false,
@@ -93,82 +92,8 @@
       ]
     },
     {
-      "customType": "BABYLON.DivideBlock",
-      "id": 5862,
-      "name": "Divide",
-      "comments": "",
-      "visibleInInspector": false,
-      "visibleOnFrame": false,
-      "target": 2,
-      "inputs": [
-        {
-          "name": "left",
-          "displayName": "left",
-          "inputName": "left",
-          "targetBlockId": 5863,
-          "targetConnectionName": "x",
-          "isExposedOnFrame": true,
-          "exposedPortPosition": -1
-        },
-        {
-          "name": "right",
-          "displayName": "right",
-          "inputName": "right",
-          "targetBlockId": 5864,
-          "targetConnectionName": "x",
-          "isExposedOnFrame": true,
-          "exposedPortPosition": -1
-        }
-      ],
-      "outputs": [
-        {
-          "name": "output",
-          "displayName": "x",
-          "isExposedOnFrame": true,
-          "exposedPortPosition": -1
-        }
-      ]
-    },
-    {
-      "customType": "BABYLON.DivideBlock",
-      "id": 5865,
-      "name": "Divide",
-      "comments": "",
-      "visibleInInspector": false,
-      "visibleOnFrame": false,
-      "target": 2,
-      "inputs": [
-        {
-          "name": "left",
-          "displayName": "left",
-          "inputName": "left",
-          "targetBlockId": 5863,
-          "targetConnectionName": "y",
-          "isExposedOnFrame": true,
-          "exposedPortPosition": -1
-        },
-        {
-          "name": "right",
-          "displayName": "right",
-          "inputName": "right",
-          "targetBlockId": 5864,
-          "targetConnectionName": "y",
-          "isExposedOnFrame": true,
-          "exposedPortPosition": -1
-        }
-      ],
-      "outputs": [
-        {
-          "name": "output",
-          "displayName": "y",
-          "isExposedOnFrame": true,
-          "exposedPortPosition": -1
-        }
-      ]
-    },
-    {
       "customType": "BABYLON.ScreenSizeBlock",
-      "id": 5864,
+      "id": 868,
       "name": "ScreenSize",
       "comments": "",
       "visibleInInspector": false,
@@ -191,8 +116,82 @@
       ]
     },
     {
+      "customType": "BABYLON.DivideBlock",
+      "id": 866,
+      "name": "Divide",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 2,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "left",
+          "inputName": "left",
+          "targetBlockId": 865,
+          "targetConnectionName": "x",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 868,
+          "targetConnectionName": "x",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "x",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.DivideBlock",
+      "id": 867,
+      "name": "Divide",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 2,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "left",
+          "inputName": "left",
+          "targetBlockId": 865,
+          "targetConnectionName": "y",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 868,
+          "targetConnectionName": "y",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "y",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ]
+    },
+    {
       "customType": "BABYLON.VectorMergerBlock",
-      "id": 5861,
+      "id": 869,
       "name": "VectorMerger",
       "comments": "",
       "visibleInInspector": false,
@@ -215,7 +214,7 @@
           "name": "x",
           "displayName": "x",
           "inputName": "x",
-          "targetBlockId": 5862,
+          "targetBlockId": 866,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -224,7 +223,7 @@
           "name": "y",
           "displayName": "y",
           "inputName": "y",
-          "targetBlockId": 5865,
+          "targetBlockId": 867,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1

--- a/nme/customFrames/screenPosition.json
+++ b/nme/customFrames/screenPosition.json
@@ -1,0 +1,265 @@
+{
+  "editorData": {
+    "locations": [
+      {
+        "blockId": 5863,
+        "x": 280,
+        "y": 1000
+      },
+      {
+        "blockId": 5862,
+        "x": 660,
+        "y": 1000
+      },
+      {
+        "blockId": 5865,
+        "x": 660,
+        "y": 1180
+      },
+      {
+        "blockId": 5864,
+        "x": 280,
+        "y": 1240
+      },
+      {
+        "blockId": 5861,
+        "x": 1000,
+        "y": 1040
+      }
+    ],
+    "frames": [
+      {
+        "x": 140,
+        "y": 940,
+        "width": 1233.17,
+        "height": 140,
+        "color": [
+          0.0392156862745098,
+          0.15294117647058825,
+          0.06666666666666667
+        ],
+        "name": "Screen Position",
+        "isCollapsed": true,
+        "blocks": [
+          5863,
+          5862,
+          5865,
+          5864,
+          5861
+        ],
+        "comments": "Screen position [0..1]"
+      }
+    ]
+  },
+  "blocks": [
+    {
+      "customType": "BABYLON.FragCoordBlock",
+      "id": 5863,
+      "name": "FragCoord",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 2,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "xy",
+          "displayName": "xy"
+        },
+        {
+          "name": "xyz",
+          "displayName": "xyz"
+        },
+        {
+          "name": "xyzw",
+          "displayName": "xyzw"
+        },
+        {
+          "name": "x",
+          "displayName": "x"
+        },
+        {
+          "name": "y",
+          "displayName": "y"
+        },
+        {
+          "name": "z",
+          "displayName": "z"
+        },
+        {
+          "name": "w",
+          "displayName": "w"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.DivideBlock",
+      "id": 5862,
+      "name": "Divide",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 2,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "left",
+          "inputName": "left",
+          "targetBlockId": 5863,
+          "targetConnectionName": "x",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 5864,
+          "targetConnectionName": "x",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "x",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.DivideBlock",
+      "id": 5865,
+      "name": "Divide",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 2,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "left",
+          "inputName": "left",
+          "targetBlockId": 5863,
+          "targetConnectionName": "y",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 5864,
+          "targetConnectionName": "y",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "y",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.ScreenSizeBlock",
+      "id": 5864,
+      "name": "ScreenSize",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 2,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "xy",
+          "displayName": "xy"
+        },
+        {
+          "name": "x",
+          "displayName": "x"
+        },
+        {
+          "name": "y",
+          "displayName": "y"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.VectorMergerBlock",
+      "id": 5861,
+      "name": "VectorMerger",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 2,
+      "inputs": [
+        {
+          "name": "xyz ",
+          "displayName": "xyz "
+        },
+        {
+          "name": "xy ",
+          "displayName": "xy "
+        },
+        {
+          "name": "zw ",
+          "displayName": "zw "
+        },
+        {
+          "name": "x",
+          "displayName": "x",
+          "inputName": "x",
+          "targetBlockId": 5862,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "y",
+          "displayName": "y",
+          "inputName": "y",
+          "targetBlockId": 5865,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "z",
+          "displayName": "z"
+        },
+        {
+          "name": "w",
+          "displayName": "w"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "xyzw",
+          "displayName": "xyzw"
+        },
+        {
+          "name": "xyz",
+          "displayName": "xyz",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 0
+        },
+        {
+          "name": "xy",
+          "displayName": "xy",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 1
+        },
+        {
+          "name": "zw",
+          "displayName": "zw"
+        }
+      ]
+    }
+  ]
+}

--- a/nme/customFrames/tileAndOffset.json
+++ b/nme/customFrames/tileAndOffset.json
@@ -2,56 +2,56 @@
   "editorData": {
     "locations": [
       {
-        "blockId": 5875,
-        "x": 80,
-        "y": 1380
+        "blockId": 902,
+        "x": -770,
+        "y": 595
       },
       {
-        "blockId": 5871,
-        "x": 380,
-        "y": 1380
+        "blockId": 903,
+        "x": -490,
+        "y": 595
       },
       {
-        "blockId": 5869,
-        "x": 660,
-        "y": 1320
+        "blockId": 904,
+        "x": -210,
+        "y": 525
       },
       {
-        "blockId": 5878,
-        "x": 380,
-        "y": 1520
+        "blockId": 905,
+        "x": -490,
+        "y": 735
       },
       {
-        "blockId": 5877,
-        "x": 660,
-        "y": 1560
+        "blockId": 906,
+        "x": -210,
+        "y": 770
       },
       {
-        "blockId": 5868,
-        "x": 940,
-        "y": 1360
+        "blockId": 907,
+        "x": 70,
+        "y": 560
       }
     ],
     "frames": [
       {
-        "x": -20,
-        "y": 1260,
+        "x": -875,
+        "y": 455,
         "width": 1215.6,
-        "height": 460,
+        "height": 455,
         "color": [
           0.027450980392156862,
           0.1568627450980392,
           0.2549019607843137
         ],
-        "name": "Tile and Offset",
+        "name": "TileAndOffset",
         "isCollapsed": true,
         "blocks": [
-          5875,
-          5871,
-          5869,
-          5878,
-          5877,
-          5868
+          902,
+          903,
+          904,
+          905,
+          906,
+          907
         ]
       }
     ]
@@ -59,7 +59,7 @@
   "blocks": [
     {
       "customType": "BABYLON.VectorSplitterBlock",
-      "id": 5875,
+      "id": 902,
       "name": "VectorSplitter",
       "comments": "",
       "visibleInInspector": false,
@@ -77,9 +77,6 @@
         {
           "name": "xy ",
           "displayName": "xy ",
-          "inputName": "xy ",
-          "targetBlockId": 5876,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 0
         }
@@ -117,7 +114,7 @@
     },
     {
       "customType": "BABYLON.AddBlock",
-      "id": 5871,
+      "id": 903,
       "name": "Add",
       "comments": "",
       "visibleInInspector": false,
@@ -127,9 +124,6 @@
         {
           "name": "left",
           "displayName": "offsetX",
-          "inputName": "left",
-          "targetBlockId": 5872,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 3
         },
@@ -137,7 +131,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 5875,
+          "targetBlockId": 902,
           "targetConnectionName": "x",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -152,7 +146,7 @@
     },
     {
       "customType": "BABYLON.MultiplyBlock",
-      "id": 5869,
+      "id": 904,
       "name": "Multiply",
       "comments": "",
       "visibleInInspector": false,
@@ -162,9 +156,6 @@
         {
           "name": "left",
           "displayName": "tileX",
-          "inputName": "left",
-          "targetBlockId": 5870,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 1
         },
@@ -172,7 +163,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 5871,
+          "targetBlockId": 903,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -187,7 +178,7 @@
     },
     {
       "customType": "BABYLON.AddBlock",
-      "id": 5878,
+      "id": 905,
       "name": "Add",
       "comments": "",
       "visibleInInspector": false,
@@ -198,7 +189,7 @@
           "name": "left",
           "displayName": "left",
           "inputName": "left",
-          "targetBlockId": 5875,
+          "targetBlockId": 902,
           "targetConnectionName": "y",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -206,9 +197,6 @@
         {
           "name": "right",
           "displayName": "offsetY",
-          "inputName": "right",
-          "targetBlockId": 5872,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 4
         }
@@ -222,7 +210,7 @@
     },
     {
       "customType": "BABYLON.MultiplyBlock",
-      "id": 5877,
+      "id": 906,
       "name": "Multiply",
       "comments": "",
       "visibleInInspector": false,
@@ -233,7 +221,7 @@
           "name": "left",
           "displayName": "left",
           "inputName": "left",
-          "targetBlockId": 5878,
+          "targetBlockId": 905,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -241,9 +229,6 @@
         {
           "name": "right",
           "displayName": "tileY",
-          "inputName": "right",
-          "targetBlockId": 5870,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 2
         }
@@ -257,7 +242,7 @@
     },
     {
       "customType": "BABYLON.VectorMergerBlock",
-      "id": 5868,
+      "id": 907,
       "name": "VectorMerger",
       "comments": "",
       "visibleInInspector": false,
@@ -280,7 +265,7 @@
           "name": "x",
           "displayName": "x",
           "inputName": "x",
-          "targetBlockId": 5869,
+          "targetBlockId": 904,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -289,7 +274,7 @@
           "name": "y",
           "displayName": "y",
           "inputName": "y",
-          "targetBlockId": 5877,
+          "targetBlockId": 906,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1

--- a/nme/customFrames/tileAndOffset.json
+++ b/nme/customFrames/tileAndOffset.json
@@ -2,42 +2,42 @@
   "editorData": {
     "locations": [
       {
-        "blockId": 33829,
-        "x": 1400,
-        "y": 840
+        "blockId": 5875,
+        "x": 80,
+        "y": 1380
       },
       {
-        "blockId": 33823,
-        "x": 1700,
-        "y": 840
+        "blockId": 5871,
+        "x": 380,
+        "y": 1380
       },
       {
-        "blockId": 33822,
-        "x": 1980,
-        "y": 780
+        "blockId": 5869,
+        "x": 660,
+        "y": 1320
       },
       {
-        "blockId": 33833,
-        "x": 1700,
-        "y": 980
+        "blockId": 5878,
+        "x": 380,
+        "y": 1520
       },
       {
-        "blockId": 33832,
-        "x": 1980,
-        "y": 1020
+        "blockId": 5877,
+        "x": 660,
+        "y": 1560
       },
       {
-        "blockId": 33821,
-        "x": 2260,
-        "y": 820
+        "blockId": 5868,
+        "x": 940,
+        "y": 1360
       }
     ],
     "frames": [
       {
-        "x": 1300,
-        "y": 720,
+        "x": -20,
+        "y": 1260,
         "width": 1215.6,
-        "height": 440.988,
+        "height": 460,
         "color": [
           0.027450980392156862,
           0.1568627450980392,
@@ -46,12 +46,12 @@
         "name": "Tile and Offset",
         "isCollapsed": true,
         "blocks": [
-          33829,
-          33823,
-          33822,
-          33833,
-          33832,
-          33821
+          5875,
+          5871,
+          5869,
+          5878,
+          5877,
+          5868
         ]
       }
     ]
@@ -59,7 +59,7 @@
   "blocks": [
     {
       "customType": "BABYLON.VectorSplitterBlock",
-      "id": 33829,
+      "id": 5875,
       "name": "VectorSplitter",
       "comments": "",
       "visibleInInspector": false,
@@ -78,7 +78,7 @@
           "name": "xy ",
           "displayName": "xy ",
           "inputName": "xy ",
-          "targetBlockId": 33830,
+          "targetBlockId": 5876,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 0
@@ -117,7 +117,7 @@
     },
     {
       "customType": "BABYLON.AddBlock",
-      "id": 33823,
+      "id": 5871,
       "name": "Add",
       "comments": "",
       "visibleInInspector": false,
@@ -128,7 +128,7 @@
           "name": "left",
           "displayName": "offsetX",
           "inputName": "left",
-          "targetBlockId": 33824,
+          "targetBlockId": 5872,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 3
@@ -137,7 +137,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 33829,
+          "targetBlockId": 5875,
           "targetConnectionName": "x",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -152,7 +152,7 @@
     },
     {
       "customType": "BABYLON.MultiplyBlock",
-      "id": 33822,
+      "id": 5869,
       "name": "Multiply",
       "comments": "",
       "visibleInInspector": false,
@@ -163,7 +163,7 @@
           "name": "left",
           "displayName": "tileX",
           "inputName": "left",
-          "targetBlockId": 33831,
+          "targetBlockId": 5870,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 1
@@ -172,7 +172,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 33823,
+          "targetBlockId": 5871,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -187,7 +187,7 @@
     },
     {
       "customType": "BABYLON.AddBlock",
-      "id": 33833,
+      "id": 5878,
       "name": "Add",
       "comments": "",
       "visibleInInspector": false,
@@ -198,7 +198,7 @@
           "name": "left",
           "displayName": "left",
           "inputName": "left",
-          "targetBlockId": 33829,
+          "targetBlockId": 5875,
           "targetConnectionName": "y",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -207,7 +207,7 @@
           "name": "right",
           "displayName": "offsetY",
           "inputName": "right",
-          "targetBlockId": 33834,
+          "targetBlockId": 5872,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 4
@@ -222,7 +222,7 @@
     },
     {
       "customType": "BABYLON.MultiplyBlock",
-      "id": 33832,
+      "id": 5877,
       "name": "Multiply",
       "comments": "",
       "visibleInInspector": false,
@@ -233,7 +233,7 @@
           "name": "left",
           "displayName": "left",
           "inputName": "left",
-          "targetBlockId": 33833,
+          "targetBlockId": 5878,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -242,7 +242,7 @@
           "name": "right",
           "displayName": "tileY",
           "inputName": "right",
-          "targetBlockId": 33838,
+          "targetBlockId": 5870,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 2
@@ -257,7 +257,7 @@
     },
     {
       "customType": "BABYLON.VectorMergerBlock",
-      "id": 33821,
+      "id": 5868,
       "name": "VectorMerger",
       "comments": "",
       "visibleInInspector": false,
@@ -280,7 +280,7 @@
           "name": "x",
           "displayName": "x",
           "inputName": "x",
-          "targetBlockId": 33822,
+          "targetBlockId": 5869,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -289,7 +289,7 @@
           "name": "y",
           "displayName": "y",
           "inputName": "y",
-          "targetBlockId": 33832,
+          "targetBlockId": 5877,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1

--- a/nme/customFrames/uvTwirl.json
+++ b/nme/customFrames/uvTwirl.json
@@ -2,134 +2,134 @@
   "editorData": {
     "locations": [
       {
-        "blockId": 101090,
-        "x": 420,
-        "y": 1190
+        "blockId": 908,
+        "x": -315,
+        "y": 490
       },
       {
-        "blockId": 101088,
-        "x": 735,
-        "y": 910
+        "blockId": 909,
+        "x": 0,
+        "y": 210
       },
       {
-        "blockId": 101093,
-        "x": 770,
+        "blockId": 910,
+        "x": 35,
+        "y": 0
+      },
+      {
+        "blockId": 911,
+        "x": 350,
+        "y": 70
+      },
+      {
+        "blockId": 912,
+        "x": 630,
+        "y": 0
+      },
+      {
+        "blockId": 913,
+        "x": 910,
+        "y": -70
+      },
+      {
+        "blockId": 914,
+        "x": 1330,
+        "y": 35
+      },
+      {
+        "blockId": 915,
+        "x": -315,
+        "y": 315
+      },
+      {
+        "blockId": 916,
+        "x": 525,
+        "y": 245
+      },
+      {
+        "blockId": 917,
+        "x": 1680,
+        "y": 175
+      },
+      {
+        "blockId": 918,
+        "x": 1330,
+        "y": 175
+      },
+      {
+        "blockId": 919,
+        "x": 1680,
+        "y": 350
+      },
+      {
+        "blockId": 920,
+        "x": 1960,
+        "y": 245
+      },
+      {
+        "blockId": 921,
+        "x": 1330,
+        "y": 560
+      },
+      {
+        "blockId": 922,
+        "x": 1680,
+        "y": 525
+      },
+      {
+        "blockId": 923,
+        "x": 1330,
+        "y": 315
+      },
+      {
+        "blockId": 924,
+        "x": 1680,
         "y": 700
       },
       {
-        "blockId": 101087,
-        "x": 1085,
-        "y": 770
+        "blockId": 925,
+        "x": 1960,
+        "y": 595
       },
       {
-        "blockId": 101085,
-        "x": 1365,
-        "y": 700
-      },
-      {
-        "blockId": 101083,
-        "x": 1645,
-        "y": 630
-      },
-      {
-        "blockId": 101082,
-        "x": 2065,
-        "y": 735
-      },
-      {
-        "blockId": 101095,
-        "x": 420,
-        "y": 1015
-      },
-      {
-        "blockId": 101094,
-        "x": 1260,
-        "y": 945
-      },
-      {
-        "blockId": 101081,
-        "x": 2415,
-        "y": 875
-      },
-      {
-        "blockId": 101097,
-        "x": 2065,
-        "y": 875
-      },
-      {
-        "blockId": 101096,
-        "x": 2415,
-        "y": 1050
-      },
-      {
-        "blockId": 101080,
-        "x": 2695,
-        "y": 945
-      },
-      {
-        "blockId": 101100,
-        "x": 2065,
-        "y": 1260
-      },
-      {
-        "blockId": 101099,
-        "x": 2415,
-        "y": 1225
-      },
-      {
-        "blockId": 101102,
-        "x": 2065,
-        "y": 1015
-      },
-      {
-        "blockId": 101101,
-        "x": 2415,
-        "y": 1400
-      },
-      {
-        "blockId": 101098,
-        "x": 2695,
-        "y": 1295
-      },
-      {
-        "blockId": 101079,
-        "x": 3010,
-        "y": 1015
+        "blockId": 926,
+        "x": 2275,
+        "y": 315
       }
     ],
     "frames": [
       {
-        "x": 245,
-        "y": 455,
+        "x": -490,
+        "y": -245,
         "width": 3061.81,
-        "height": 1098.89,
+        "height": 1120,
         "color": [
           0.2196078431372549,
           0.00784313725490196,
           0.24705882352941178
         ],
-        "name": "UV Twirl",
+        "name": "UvTwirl",
         "isCollapsed": true,
         "blocks": [
-          101090,
-          101088,
-          101093,
-          101087,
-          101085,
-          101083,
-          101082,
-          101095,
-          101094,
-          101081,
-          101097,
-          101096,
-          101080,
-          101100,
-          101099,
-          101102,
-          101101,
-          101098,
-          101079
+          908,
+          909,
+          910,
+          911,
+          912,
+          913,
+          914,
+          915,
+          916,
+          917,
+          918,
+          919,
+          920,
+          921,
+          922,
+          923,
+          924,
+          925,
+          926
         ]
       }
     ]
@@ -137,7 +137,7 @@
   "blocks": [
     {
       "customType": "BABYLON.DistanceBlock",
-      "id": 101090,
+      "id": 908,
       "name": "Distance",
       "comments": "",
       "visibleInInspector": false,
@@ -147,18 +147,12 @@
         {
           "name": "left",
           "displayName": "uv",
-          "inputName": "left",
-          "targetBlockId": 101091,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 0
         },
         {
           "name": "right",
           "displayName": "center",
-          "inputName": "right",
-          "targetBlockId": 101092,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 2
         }
@@ -172,7 +166,7 @@
     },
     {
       "customType": "BABYLON.SubtractBlock",
-      "id": 101088,
+      "id": 909,
       "name": "Subtract",
       "comments": "",
       "visibleInInspector": false,
@@ -182,9 +176,6 @@
         {
           "name": "left",
           "displayName": "radius",
-          "inputName": "left",
-          "targetBlockId": 101089,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 4
         },
@@ -192,7 +183,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 101090,
+          "targetBlockId": 908,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -207,7 +198,7 @@
     },
     {
       "customType": "BABYLON.InputBlock",
-      "id": 101093,
+      "id": 910,
       "name": "zero",
       "comments": "",
       "visibleInInspector": false,
@@ -235,7 +226,7 @@
     },
     {
       "customType": "BABYLON.SmoothStepBlock",
-      "id": 101087,
+      "id": 911,
       "name": "Smooth step",
       "comments": "",
       "visibleInInspector": false,
@@ -246,7 +237,7 @@
           "name": "value",
           "displayName": "value",
           "inputName": "value",
-          "targetBlockId": 101088,
+          "targetBlockId": 909,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -255,7 +246,7 @@
           "name": "edge0",
           "displayName": "edge0",
           "inputName": "edge0",
-          "targetBlockId": 101093,
+          "targetBlockId": 910,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -263,9 +254,6 @@
         {
           "name": "edge1",
           "displayName": "radius",
-          "inputName": "edge1",
-          "targetBlockId": 101089,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 5
         }
@@ -279,7 +267,7 @@
     },
     {
       "customType": "BABYLON.MultiplyBlock",
-      "id": 101085,
+      "id": 912,
       "name": "Multiply (d)",
       "comments": "",
       "visibleInInspector": false,
@@ -289,9 +277,6 @@
         {
           "name": "left",
           "displayName": "strength",
-          "inputName": "left",
-          "targetBlockId": 101086,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 6
         },
@@ -299,7 +284,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 101087,
+          "targetBlockId": 911,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -314,7 +299,7 @@
     },
     {
       "customType": "BABYLON.AddBlock",
-      "id": 101083,
+      "id": 913,
       "name": "Add",
       "comments": "",
       "visibleInInspector": false,
@@ -324,9 +309,6 @@
         {
           "name": "left",
           "displayName": "angle",
-          "inputName": "left",
-          "targetBlockId": 101084,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 7
         },
@@ -334,7 +316,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 101085,
+          "targetBlockId": 912,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -349,7 +331,7 @@
     },
     {
       "customType": "BABYLON.TrigonometryBlock",
-      "id": 101082,
+      "id": 914,
       "name": "Cos",
       "comments": "",
       "visibleInInspector": false,
@@ -359,7 +341,7 @@
         {
           "name": "input",
           "inputName": "input",
-          "targetBlockId": 101083,
+          "targetBlockId": 913,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -374,7 +356,7 @@
     },
     {
       "customType": "BABYLON.SubtractBlock",
-      "id": 101095,
+      "id": 915,
       "name": "Subtract",
       "comments": "",
       "visibleInInspector": false,
@@ -384,18 +366,12 @@
         {
           "name": "left",
           "displayName": "uv",
-          "inputName": "left",
-          "targetBlockId": 101091,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 1
         },
         {
           "name": "right",
           "displayName": "center",
-          "inputName": "right",
-          "targetBlockId": 101092,
-          "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": 3
         }
@@ -409,7 +385,7 @@
     },
     {
       "customType": "BABYLON.VectorSplitterBlock",
-      "id": 101094,
+      "id": 916,
       "name": "VectorSplitter",
       "comments": "",
       "visibleInInspector": false,
@@ -428,7 +404,7 @@
           "name": "xy ",
           "displayName": "xy ",
           "inputName": "xy ",
-          "targetBlockId": 101095,
+          "targetBlockId": 915,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -467,7 +443,7 @@
     },
     {
       "customType": "BABYLON.MultiplyBlock",
-      "id": 101081,
+      "id": 917,
       "name": "Multiply",
       "comments": "",
       "visibleInInspector": false,
@@ -478,7 +454,7 @@
           "name": "left",
           "displayName": "left",
           "inputName": "left",
-          "targetBlockId": 101082,
+          "targetBlockId": 914,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -487,7 +463,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 101094,
+          "targetBlockId": 916,
           "targetConnectionName": "x",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -502,7 +478,7 @@
     },
     {
       "customType": "BABYLON.TrigonometryBlock",
-      "id": 101097,
+      "id": 918,
       "name": "Sin",
       "comments": "",
       "visibleInInspector": false,
@@ -512,7 +488,7 @@
         {
           "name": "input",
           "inputName": "input",
-          "targetBlockId": 101083,
+          "targetBlockId": 913,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -527,7 +503,7 @@
     },
     {
       "customType": "BABYLON.MultiplyBlock",
-      "id": 101096,
+      "id": 919,
       "name": "Multiply",
       "comments": "",
       "visibleInInspector": false,
@@ -538,7 +514,7 @@
           "name": "left",
           "displayName": "left",
           "inputName": "left",
-          "targetBlockId": 101097,
+          "targetBlockId": 918,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -547,7 +523,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 101094,
+          "targetBlockId": 916,
           "targetConnectionName": "y",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -562,7 +538,7 @@
     },
     {
       "customType": "BABYLON.SubtractBlock",
-      "id": 101080,
+      "id": 920,
       "name": "Subtract (x)",
       "comments": "",
       "visibleInInspector": false,
@@ -573,7 +549,7 @@
           "name": "left",
           "displayName": "left",
           "inputName": "left",
-          "targetBlockId": 101081,
+          "targetBlockId": 917,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -582,7 +558,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 101096,
+          "targetBlockId": 919,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -597,7 +573,7 @@
     },
     {
       "customType": "BABYLON.TrigonometryBlock",
-      "id": 101100,
+      "id": 921,
       "name": "Sin",
       "comments": "",
       "visibleInInspector": false,
@@ -607,7 +583,7 @@
         {
           "name": "input",
           "inputName": "input",
-          "targetBlockId": 101083,
+          "targetBlockId": 913,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -622,7 +598,7 @@
     },
     {
       "customType": "BABYLON.MultiplyBlock",
-      "id": 101099,
+      "id": 922,
       "name": "Multiply",
       "comments": "",
       "visibleInInspector": false,
@@ -633,7 +609,7 @@
           "name": "left",
           "displayName": "left",
           "inputName": "left",
-          "targetBlockId": 101094,
+          "targetBlockId": 916,
           "targetConnectionName": "x",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -642,7 +618,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 101100,
+          "targetBlockId": 921,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -657,7 +633,7 @@
     },
     {
       "customType": "BABYLON.TrigonometryBlock",
-      "id": 101102,
+      "id": 923,
       "name": "Cos",
       "comments": "",
       "visibleInInspector": false,
@@ -667,7 +643,7 @@
         {
           "name": "input",
           "inputName": "input",
-          "targetBlockId": 101083,
+          "targetBlockId": 913,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -682,7 +658,7 @@
     },
     {
       "customType": "BABYLON.MultiplyBlock",
-      "id": 101101,
+      "id": 924,
       "name": "Multiply",
       "comments": "",
       "visibleInInspector": false,
@@ -693,7 +669,7 @@
           "name": "left",
           "displayName": "left",
           "inputName": "left",
-          "targetBlockId": 101102,
+          "targetBlockId": 923,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -702,7 +678,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 101094,
+          "targetBlockId": 916,
           "targetConnectionName": "y",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -717,7 +693,7 @@
     },
     {
       "customType": "BABYLON.AddBlock",
-      "id": 101098,
+      "id": 925,
       "name": "Add (y)",
       "comments": "",
       "visibleInInspector": false,
@@ -728,7 +704,7 @@
           "name": "left",
           "displayName": "left",
           "inputName": "left",
-          "targetBlockId": 101099,
+          "targetBlockId": 922,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -737,7 +713,7 @@
           "name": "right",
           "displayName": "right",
           "inputName": "right",
-          "targetBlockId": 101101,
+          "targetBlockId": 924,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -752,7 +728,7 @@
     },
     {
       "customType": "BABYLON.VectorMergerBlock",
-      "id": 101079,
+      "id": 926,
       "name": "VectorMerger",
       "comments": "",
       "visibleInInspector": false,
@@ -775,7 +751,7 @@
           "name": "x",
           "displayName": "x",
           "inputName": "x",
-          "targetBlockId": 101080,
+          "targetBlockId": 920,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1
@@ -784,7 +760,7 @@
           "name": "y",
           "displayName": "y",
           "inputName": "y",
-          "targetBlockId": 101098,
+          "targetBlockId": 925,
           "targetConnectionName": "output",
           "isExposedOnFrame": true,
           "exposedPortPosition": -1

--- a/nme/customFrames/uvTwirl.json
+++ b/nme/customFrames/uvTwirl.json
@@ -1,0 +1,823 @@
+{
+  "editorData": {
+    "locations": [
+      {
+        "blockId": 101090,
+        "x": 420,
+        "y": 1190
+      },
+      {
+        "blockId": 101088,
+        "x": 735,
+        "y": 910
+      },
+      {
+        "blockId": 101093,
+        "x": 770,
+        "y": 700
+      },
+      {
+        "blockId": 101087,
+        "x": 1085,
+        "y": 770
+      },
+      {
+        "blockId": 101085,
+        "x": 1365,
+        "y": 700
+      },
+      {
+        "blockId": 101083,
+        "x": 1645,
+        "y": 630
+      },
+      {
+        "blockId": 101082,
+        "x": 2065,
+        "y": 735
+      },
+      {
+        "blockId": 101095,
+        "x": 420,
+        "y": 1015
+      },
+      {
+        "blockId": 101094,
+        "x": 1260,
+        "y": 945
+      },
+      {
+        "blockId": 101081,
+        "x": 2415,
+        "y": 875
+      },
+      {
+        "blockId": 101097,
+        "x": 2065,
+        "y": 875
+      },
+      {
+        "blockId": 101096,
+        "x": 2415,
+        "y": 1050
+      },
+      {
+        "blockId": 101080,
+        "x": 2695,
+        "y": 945
+      },
+      {
+        "blockId": 101100,
+        "x": 2065,
+        "y": 1260
+      },
+      {
+        "blockId": 101099,
+        "x": 2415,
+        "y": 1225
+      },
+      {
+        "blockId": 101102,
+        "x": 2065,
+        "y": 1015
+      },
+      {
+        "blockId": 101101,
+        "x": 2415,
+        "y": 1400
+      },
+      {
+        "blockId": 101098,
+        "x": 2695,
+        "y": 1295
+      },
+      {
+        "blockId": 101079,
+        "x": 3010,
+        "y": 1015
+      }
+    ],
+    "frames": [
+      {
+        "x": 245,
+        "y": 455,
+        "width": 3061.81,
+        "height": 1098.89,
+        "color": [
+          0.2196078431372549,
+          0.00784313725490196,
+          0.24705882352941178
+        ],
+        "name": "UV Twirl",
+        "isCollapsed": true,
+        "blocks": [
+          101090,
+          101088,
+          101093,
+          101087,
+          101085,
+          101083,
+          101082,
+          101095,
+          101094,
+          101081,
+          101097,
+          101096,
+          101080,
+          101100,
+          101099,
+          101102,
+          101101,
+          101098,
+          101079
+        ]
+      }
+    ]
+  },
+  "blocks": [
+    {
+      "customType": "BABYLON.DistanceBlock",
+      "id": 101090,
+      "name": "Distance",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "uv",
+          "inputName": "left",
+          "targetBlockId": 101091,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 0
+        },
+        {
+          "name": "right",
+          "displayName": "center",
+          "inputName": "right",
+          "targetBlockId": 101092,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 2
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.SubtractBlock",
+      "id": 101088,
+      "name": "Subtract",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "radius",
+          "inputName": "left",
+          "targetBlockId": 101089,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 4
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 101090,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.InputBlock",
+      "id": 101093,
+      "name": "zero",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 1,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "output"
+        }
+      ],
+      "type": 1,
+      "mode": 0,
+      "animationType": 0,
+      "min": 0,
+      "max": 0,
+      "isBoolean": false,
+      "matrixMode": 0,
+      "isConstant": true,
+      "groupInInspector": "",
+      "convertToGammaSpace": false,
+      "convertToLinearSpace": false,
+      "valueType": "number",
+      "value": 0
+    },
+    {
+      "customType": "BABYLON.SmoothStepBlock",
+      "id": 101087,
+      "name": "Smooth step",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "value",
+          "displayName": "value",
+          "inputName": "value",
+          "targetBlockId": 101088,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "edge0",
+          "displayName": "edge0",
+          "inputName": "edge0",
+          "targetBlockId": 101093,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "edge1",
+          "displayName": "radius",
+          "inputName": "edge1",
+          "targetBlockId": 101089,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 5
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.MultiplyBlock",
+      "id": 101085,
+      "name": "Multiply (d)",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "strength",
+          "inputName": "left",
+          "targetBlockId": 101086,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 6
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 101087,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.AddBlock",
+      "id": 101083,
+      "name": "Add",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "angle",
+          "inputName": "left",
+          "targetBlockId": 101084,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 7
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 101085,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.TrigonometryBlock",
+      "id": 101082,
+      "name": "Cos",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "input",
+          "inputName": "input",
+          "targetBlockId": 101083,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output"
+        }
+      ],
+      "operation": 0
+    },
+    {
+      "customType": "BABYLON.SubtractBlock",
+      "id": 101095,
+      "name": "Subtract",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "uv",
+          "inputName": "left",
+          "targetBlockId": 101091,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 1
+        },
+        {
+          "name": "right",
+          "displayName": "center",
+          "inputName": "right",
+          "targetBlockId": 101092,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 3
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.VectorSplitterBlock",
+      "id": 101094,
+      "name": "VectorSplitter",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "xyzw",
+          "displayName": "xyzw"
+        },
+        {
+          "name": "xyz ",
+          "displayName": "xyz "
+        },
+        {
+          "name": "xy ",
+          "displayName": "xy ",
+          "inputName": "xy ",
+          "targetBlockId": 101095,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "xyz",
+          "displayName": "xyz"
+        },
+        {
+          "name": "xy",
+          "displayName": "xy"
+        },
+        {
+          "name": "zw",
+          "displayName": "zw"
+        },
+        {
+          "name": "x",
+          "displayName": "x"
+        },
+        {
+          "name": "y",
+          "displayName": "y"
+        },
+        {
+          "name": "z",
+          "displayName": "z"
+        },
+        {
+          "name": "w",
+          "displayName": "w"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.MultiplyBlock",
+      "id": 101081,
+      "name": "Multiply",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "left",
+          "inputName": "left",
+          "targetBlockId": 101082,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 101094,
+          "targetConnectionName": "x",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.TrigonometryBlock",
+      "id": 101097,
+      "name": "Sin",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "input",
+          "inputName": "input",
+          "targetBlockId": 101083,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output"
+        }
+      ],
+      "operation": 1
+    },
+    {
+      "customType": "BABYLON.MultiplyBlock",
+      "id": 101096,
+      "name": "Multiply",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "left",
+          "inputName": "left",
+          "targetBlockId": 101097,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 101094,
+          "targetConnectionName": "y",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.SubtractBlock",
+      "id": 101080,
+      "name": "Subtract (x)",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "left",
+          "inputName": "left",
+          "targetBlockId": 101081,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 101096,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.TrigonometryBlock",
+      "id": 101100,
+      "name": "Sin",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "input",
+          "inputName": "input",
+          "targetBlockId": 101083,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output"
+        }
+      ],
+      "operation": 1
+    },
+    {
+      "customType": "BABYLON.MultiplyBlock",
+      "id": 101099,
+      "name": "Multiply",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "left",
+          "inputName": "left",
+          "targetBlockId": 101094,
+          "targetConnectionName": "x",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 101100,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.TrigonometryBlock",
+      "id": 101102,
+      "name": "Cos",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "input",
+          "inputName": "input",
+          "targetBlockId": 101083,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output"
+        }
+      ],
+      "operation": 0
+    },
+    {
+      "customType": "BABYLON.MultiplyBlock",
+      "id": 101101,
+      "name": "Multiply",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "left",
+          "inputName": "left",
+          "targetBlockId": 101102,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 101094,
+          "targetConnectionName": "y",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.AddBlock",
+      "id": 101098,
+      "name": "Add (y)",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "left",
+          "displayName": "left",
+          "inputName": "left",
+          "targetBlockId": 101099,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "right",
+          "displayName": "right",
+          "inputName": "right",
+          "targetBlockId": 101101,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "displayName": "output"
+        }
+      ]
+    },
+    {
+      "customType": "BABYLON.VectorMergerBlock",
+      "id": 101079,
+      "name": "VectorMerger",
+      "comments": "",
+      "visibleInInspector": false,
+      "visibleOnFrame": false,
+      "target": 4,
+      "inputs": [
+        {
+          "name": "xyz ",
+          "displayName": "xyz "
+        },
+        {
+          "name": "xy ",
+          "displayName": "xy "
+        },
+        {
+          "name": "zw ",
+          "displayName": "zw "
+        },
+        {
+          "name": "x",
+          "displayName": "x",
+          "inputName": "x",
+          "targetBlockId": 101080,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "y",
+          "displayName": "y",
+          "inputName": "y",
+          "targetBlockId": 101098,
+          "targetConnectionName": "output",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": -1
+        },
+        {
+          "name": "z",
+          "displayName": "z"
+        },
+        {
+          "name": "w",
+          "displayName": "w"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "xyzw",
+          "displayName": "xyzw"
+        },
+        {
+          "name": "xyz",
+          "displayName": "xyz"
+        },
+        {
+          "name": "xy",
+          "displayName": "xy",
+          "isExposedOnFrame": true,
+          "exposedPortPosition": 0
+        },
+        {
+          "name": "zw",
+          "displayName": "zw"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hello guys! 
The web is full of Unity Shader Graph examples so I started to create some of the Unity shader graph nodes in the NME so I can follow these tutorials more easily. The nodes are not a 100% copy of the Unity shader nodes, but they should behave in a very similar way.  So here is a UV Twirl node and a Screen Position node (only for fragment shaders). If you spot something lame, please let me know, I would not like to share poorly designed nodes. Thanks!